### PR TITLE
Improve language handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,16 @@
-from pipeline import run_pipeline
+from pipeline import run_pipeline_stream
+
+RED = "\033[91m"
+GREEN = "\033[92m"
+RESET = "\033[0m"
 
 if __name__ == "__main__":
     while True:
-        user_input = input("User: ")
+        user_input = input(f"{RED}User{RESET}: ")
         if user_input.lower() in ["quit", "exit"]:
             break
-        output = run_pipeline(user_input)
-        print("Bot:", output)
+
+        print(f"{GREEN}[Bot] ", end="", flush=True)
+        for token in run_pipeline_stream(user_input):
+            print(token, end="", flush=True)
+        print(RESET)

--- a/models/mistral.py
+++ b/models/mistral.py
@@ -1,7 +1,32 @@
 import subprocess
+from typing import Iterator
 
 def call_mistral(prompt: str) -> str:
     cmd = ["ollama", "run", "mistral"]
     proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     out, _ = proc.communicate(prompt)
     return out.strip()
+
+
+def stream_mistral(prompt: str) -> Iterator[str]:
+    """Yield the Mistral response incrementally."""
+    cmd = ["ollama", "run", "mistral"]
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    assert proc.stdin is not None
+    proc.stdin.write(prompt)
+    proc.stdin.close()
+
+    assert proc.stdout is not None
+    while True:
+        ch = proc.stdout.read(1)
+        if not ch:
+            break
+        yield ch
+    proc.wait()

--- a/models/openchat.py
+++ b/models/openchat.py
@@ -1,7 +1,32 @@
 import subprocess
+from typing import Iterator
 
 def call_openchat(prompt: str) -> str:
     cmd = ["ollama", "run", "openchat"]
     proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     out, _ = proc.communicate(prompt)
     return out.strip()
+
+
+def stream_openchat(prompt: str) -> Iterator[str]:
+    """Yield the OpenChat response incrementally."""
+    cmd = ["ollama", "run", "openchat"]
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    assert proc.stdin is not None
+    proc.stdin.write(prompt)
+    proc.stdin.close()
+
+    assert proc.stdout is not None
+    while True:
+        ch = proc.stdout.read(1)
+        if not ch:
+            break
+        yield ch
+    proc.wait()

--- a/openchat_worker.py
+++ b/openchat_worker.py
@@ -1,12 +1,30 @@
-from models.openchat import call_openchat
+from typing import Iterator
+
+from models.openchat import call_openchat, stream_openchat
 
 
-def generate_response(user_input: str, intent: str) -> str:
-    """Generate a helpful answer using OpenChat."""
+def generate_response(user_input: str, intent: str, lang: str) -> str:
+    """Generate a helpful answer using OpenChat.
+
+    The assistant is instructed to reply in the same language as the
+    user's message.
+    """
 
     prompt = (
         f"The user asked: {user_input}\n"
         f"Detected intent: {intent}.\n"
+        f"Reply in language: {lang}.\n"
         "Provide a clear, helpful response."
     )
     return call_openchat(prompt)
+
+
+def generate_response_stream(user_input: str, intent: str, lang: str) -> Iterator[str]:
+    """Stream a response from OpenChat."""
+    prompt = (
+        f"The user asked: {user_input}\n"
+        f"Detected intent: {intent}.\n"
+        f"Reply in language: {lang}.\n"
+        "Provide a clear, helpful response."
+    )
+    return stream_openchat(prompt)

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,8 +1,9 @@
 from intent_router import detect_intent
-from openchat_worker import generate_response
+from openchat_worker import generate_response, generate_response_stream
 from verifier import verify_response
 from clarification_prompt import generate_fallback_question
 from language_detector import detect_language
+from translator import translate, translate_stream
 
 def run_pipeline(user_input: str):
     lang = detect_language(user_input)
@@ -16,10 +17,52 @@ def run_pipeline(user_input: str):
         print(f"[Generated clarification]: {question}")
         return question
 
-    response = generate_response(user_input, intent)
+    response = generate_response(user_input, intent, lang)
     print(f"[Generated response]: {response}")
+
+    detected_resp_lang = detect_language(response)
+    if detected_resp_lang != lang:
+        response = translate(response, lang)
+        print(f"[Translated response]: {response}")
 
     verified = verify_response(user_input, response)
     print(f"[Response verification]: {'✅ OK' if verified else '❌ INVALID'}")
 
     return response if verified else generate_fallback_question(user_input)
+
+
+def run_pipeline_stream(user_input: str):
+    """Run the pipeline yielding tokens as soon as they are produced."""
+    lang = detect_language(user_input)
+    print(f"[Detected language]: {lang}")
+
+    intent = detect_intent(user_input)
+    print(f"[Detected intent]: {intent}")
+
+    if intent is None:
+        question = generate_fallback_question(user_input)
+        print(f"[Generated clarification]: {question}")
+        yield question
+        return
+
+    stream = generate_response_stream(user_input, intent, lang)
+    collected = []
+    for token in stream:
+        collected.append(token)
+        yield token
+    response = "".join(collected)
+
+    detected_resp_lang = detect_language(response)
+    if detected_resp_lang != lang:
+        translated_tokens = list(translate_stream(response, lang))
+        response = "".join(translated_tokens)
+        print(f"[Translated response]: {response}")
+        for t in translated_tokens:
+            yield t
+
+    verified = verify_response(user_input, response)
+    print(f"[Response verification]: {'✅ OK' if verified else '❌ INVALID'}")
+    if not verified:
+        fallback = generate_fallback_question(user_input)
+        print(f"[Fallback question]: {fallback}")
+        yield fallback

--- a/translator.py
+++ b/translator.py
@@ -1,5 +1,44 @@
-def translate(text: str, target_lang: str = "en") -> str:
-    """Translate the given text to the target language."""
+"""Utility for translating text using the local LLM."""
 
-    # Temporary mock to be replaced with deep-translator or NLLB
-    return f"[translated to {target_lang}]: {text}"
+from typing import Iterator
+
+from models.mistral import call_mistral, stream_mistral
+
+
+def translate(text: str, target_lang: str = "en") -> str:
+    """Translate ``text`` to ``target_lang`` using Mistral.
+
+    Args:
+        text: The text to translate.
+        target_lang: Two letter ISO code of the desired language.
+
+    Returns:
+        The translated text. If translation fails, the original text
+        is returned unchanged.
+    """
+
+    prompt = (
+        f"Translate the following text to {target_lang}.\n"
+        "Return only the translated sentence without explanations.\n"
+        f"Text: {text}\n"
+        "Translated text:"
+    )
+
+    try:
+        return call_mistral(prompt).strip()
+    except Exception:
+        return text
+
+
+def translate_stream(text: str, target_lang: str = "en") -> Iterator[str]:
+    """Stream translated text token by token."""
+    prompt = (
+        f"Translate the following text to {target_lang}.\n"
+        "Return only the translated sentence without explanations.\n"
+        f"Text: {text}\n"
+        "Translated text:"
+    )
+    try:
+        yield from stream_mistral(prompt)
+    except Exception:
+        yield text


### PR DESCRIPTION
## Summary
- use Mistral LLM in `translator.translate`
- instruct OpenChat to respond in user's language
- detect response language and translate if needed
- stream token generation for quicker responses
- colorize user and bot messages in CLI output

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684bf75b1e74832dacda0708fa4ac551