### PR TITLE
Add Qdrant-based retrieval with role checks

### DIFF
--- a/agents/context.py
+++ b/agents/context.py
@@ -9,6 +9,7 @@ class AgentContext:
     user_id: str
     session_id: str
     input: str
+    role: str = "user"
     language: str = "en"
     intent: Optional[str] = None
     confidence: Optional[float] = None

--- a/agents/document_retriever_agent.py
+++ b/agents/document_retriever_agent.py
@@ -1,32 +1,80 @@
-"""Retrieve relevant document chunks."""
+"""Retrieve relevant document chunks using a local Qdrant instance."""
+
+from typing import List, Optional
+
+from qdrant_client import QdrantClient
+from qdrant_client.http import models as rest
 
 from agents.context import AgentContext
 from utils.logger import get_logger
-from typing import Optional
+
 
 DOCS = {
-    "manual": ["manual section 1", "manual section 2"],
-    "setup": ["setup guide"],
+    "manual": [
+        {"content": "manual section 1", "roles": ["user", "admin"]},
+        {"content": "manual section 2", "roles": ["user", "admin"]},
+    ],
+    "setup": [
+        {"content": "setup guide", "roles": ["admin"]},
+    ],
 }
 
 
-def _retrieve(query: str) -> list[str]:
-    for key, docs in DOCS.items():
-        if key in query.lower():
-            return docs
-    return []
+def _embed(text: str) -> List[float]:
+    """Generate a simple deterministic embedding vector."""
+    h = abs(hash(text))
+    return [
+        ((h >> 0) & 0xFF) / 255,
+        ((h >> 8) & 0xFF) / 255,
+        ((h >> 16) & 0xFF) / 255,
+    ]
+
+
+_client = QdrantClient(":memory:")
+_COLLECTION = "docs"
+_client.recreate_collection(
+    collection_name=_COLLECTION,
+    vectors_config=rest.VectorParams(size=3, distance=rest.Distance.COSINE),
+)
+_points: List[rest.PointStruct] = []
+idx = 1
+for docs in DOCS.values():
+    for d in docs:
+        _points.append(
+            rest.PointStruct(
+                id=idx,
+                vector=_embed(str(d["content"])),
+                payload={"content": d["content"], "roles": d["roles"]},
+            )
+        )
+        idx += 1
+_client.upsert(collection_name=_COLLECTION, points=_points)
+
+
+def _retrieve(query: str, role: str) -> List[str]:
+    qvec = _embed(query)
+    results = _client.search(
+        collection_name=_COLLECTION, query_vector=qvec, limit=5
+    )
+    allowed = []
+    for res in results:
+        payload = res.payload or {}
+        content = payload.get("content", "")
+        if role in payload.get("roles", []) and query.lower() in content.lower():
+            allowed.append(content)
+    return allowed
 
 
 logger = get_logger("retrieval_log")
 
 
 def run(context: AgentContext, query: Optional[str] = None) -> AgentContext:
-    if context.user_id == "guest":
+    if context.role == "guest":
         context.error_flag = True
         logger.info("permission denied")
         return context
 
-    docs = _retrieve(query or context.input)
+    docs = _retrieve(query or context.input, context.role)
     context.documents = docs
     context.source_reliability = 0.9 if docs else 0.5
     logger.info(f"retrieved {len(context.documents)} docs")

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,6 +4,7 @@ from agents.context import AgentContext
 def test_defaults():
     ctx = AgentContext(user_id="u", session_id="s", input="hi")
     assert ctx.language == "en"
+    assert ctx.role == "user"
     assert ctx.intent is None
     assert ctx.documents == []
     assert ctx.source_reliability == 0.0

--- a/tests/test_document_retriever_agent.py
+++ b/tests/test_document_retriever_agent.py
@@ -3,14 +3,20 @@ from agents.document_retriever_agent import run
 
 
 def test_document_retriever_agent():
-    ctx = AgentContext(user_id="u", session_id="s", input="manual")
+    ctx = AgentContext(user_id="u", session_id="s", role="user", input="manual")
     run(ctx)
     assert len(ctx.documents) == 2
     assert ctx.source_reliability == 0.9
 
 
 def test_document_retriever_permission_denied():
-    ctx = AgentContext(user_id="guest", session_id="s", input="manual")
+    ctx = AgentContext(user_id="g", session_id="s", role="guest", input="manual")
     run(ctx)
     assert ctx.error_flag is True
     assert ctx.documents == []
+
+
+def test_admin_access_setup():
+    ctx = AgentContext(user_id="a", session_id="s", role="admin", input="setup")
+    run(ctx)
+    assert ctx.documents == ["setup guide"]


### PR DESCRIPTION

- extend `AgentContext` with a `role` field
- integrate an in-memory Qdrant client in `DocumentRetrieverAgent`
- enforce role-based permission during retrieval
- update tests for new behaviour and context field
