### PR TITLE
Add transparency fields to logs

### DIFF
--- a/agents/action_agent.py
+++ b/agents/action_agent.py
@@ -10,8 +10,13 @@ logger = get_logger("action_log")
 def run(context: AgentContext) -> AgentContext:
     # Example action placeholder
     context.source_reliability = 0.8
-    logger.info(f"action for intent {context.intent}")
     logger.info(
-        f"reliability={context.source_reliability} error={context.error_flag}"
+        f"action for intent {context.intent}",
+        extra={
+            "confidence_score": context.confidence,
+            "source_reliability": context.source_reliability,
+            "clarification_attempted": context.clarification_attempted,
+            "error_flag": context.error_flag,
+        },
     )
     return context

--- a/agents/clarification_agent.py
+++ b/agents/clarification_agent.py
@@ -30,8 +30,13 @@ def run(context: AgentContext) -> AgentContext:
         question = f"Gentile utente, {question}"
     context.response = question
     context.clarification_attempted = True
-    logger.info(question)
     logger.info(
-        f"reliability={context.source_reliability} error={context.error_flag}"
+        question,
+        extra={
+            "confidence_score": context.confidence,
+            "source_reliability": context.source_reliability,
+            "clarification_attempted": context.clarification_attempted,
+            "error_flag": context.error_flag,
+        },
     )
     return context

--- a/agents/document_retriever_agent.py
+++ b/agents/document_retriever_agent.py
@@ -71,14 +71,27 @@ logger = get_logger("retrieval_log")
 def run(context: AgentContext, query: Optional[str] = None) -> AgentContext:
     if context.role == "guest":
         context.error_flag = True
-        logger.info("permission denied")
+        logger.info(
+            "permission denied",
+            extra={
+                "confidence_score": context.confidence,
+                "source_reliability": context.source_reliability,
+                "clarification_attempted": context.clarification_attempted,
+                "error_flag": context.error_flag,
+            },
+        )
         return context
 
     docs = _retrieve(query or context.input, context.role)
     context.documents = docs
     context.source_reliability = 0.9 if docs else 0.5
-    logger.info(f"retrieved {len(context.documents)} docs")
     logger.info(
-        f"reliability={context.source_reliability} error={context.error_flag}"
+        f"retrieved {len(context.documents)} docs",
+        extra={
+            "confidence_score": context.confidence,
+            "source_reliability": context.source_reliability,
+            "clarification_attempted": context.clarification_attempted,
+            "error_flag": context.error_flag,
+        },
     )
     return context

--- a/agents/embedding_ingestor_agent.py
+++ b/agents/embedding_ingestor_agent.py
@@ -19,8 +19,13 @@ def run(context: AgentContext, path: str | Path) -> AgentContext:
     embeddings = [hash(c) % 1000 for c in chunks]
     context.documents = [f"{path.name}-{i}" for i, _ in enumerate(embeddings)]
     context.source_reliability = 1.0
-    logger.info(f"ingested {len(chunks)} chunks from {path.name}")
     logger.info(
-        f"reliability={context.source_reliability} error={context.error_flag}"
+        f"ingested {len(chunks)} chunks from {path.name}",
+        extra={
+            "confidence_score": context.confidence,
+            "source_reliability": context.source_reliability,
+            "clarification_attempted": context.clarification_attempted,
+            "error_flag": context.error_flag,
+        },
     )
     return context

--- a/agents/intent_agent.py
+++ b/agents/intent_agent.py
@@ -121,8 +121,13 @@ def run(context: AgentContext) -> AgentContext:
     context.intent = intent
     context.confidence = confidence
     context.source_reliability = confidence
-    logger.info(intent if intent else "unclear")
     logger.info(
-        f"reliability={context.source_reliability} error={context.error_flag}"
+        intent if intent else "unclear",
+        extra={
+            "confidence_score": context.confidence,
+            "source_reliability": context.source_reliability,
+            "clarification_attempted": context.clarification_attempted,
+            "error_flag": context.error_flag,
+        },
     )
     return context

--- a/agents/language_agent.py
+++ b/agents/language_agent.py
@@ -52,8 +52,13 @@ def run(context: AgentContext) -> AgentContext:
     context.formality = _detect_formality(text)
     context.mixed_language = _mixed_language(text)
     context.source_reliability = 0.7
-    logger.info(f"{lang} {context.formality} mixed={context.mixed_language}")
     logger.info(
-        f"reliability={context.source_reliability} error={context.error_flag}"
+        f"{lang} {context.formality} mixed={context.mixed_language}",
+        extra={
+            "confidence_score": context.confidence,
+            "source_reliability": context.source_reliability,
+            "clarification_attempted": context.clarification_attempted,
+            "error_flag": context.error_flag,
+        },
     )
     return context

--- a/agents/orchestrator_agent.py
+++ b/agents/orchestrator_agent.py
@@ -21,7 +21,15 @@ def choose_agent_sequence(context: AgentContext):
     else:
         context.reasoning_trace = "default flow"
         seq = [detect_language, detect_intent, generate_response]
-    logger.info(context.reasoning_trace)
+    logger.info(
+        context.reasoning_trace,
+        extra={
+            "confidence_score": context.confidence,
+            "source_reliability": context.source_reliability,
+            "clarification_attempted": context.clarification_attempted,
+            "error_flag": context.error_flag,
+        },
+    )
     return seq
 
 
@@ -37,8 +45,13 @@ def run(context: AgentContext) -> AgentContext:
         clarify(context)
 
     translate(context, context.language)
-    logger.info("orchestration complete")
     logger.info(
-        f"reliability={context.source_reliability} error={context.error_flag}"
+        "orchestration complete",
+        extra={
+            "confidence_score": context.confidence,
+            "source_reliability": context.source_reliability,
+            "clarification_attempted": context.clarification_attempted,
+            "error_flag": context.error_flag,
+        },
     )
     return context

--- a/agents/quotation_agent.py
+++ b/agents/quotation_agent.py
@@ -10,8 +10,13 @@ logger = get_logger("quotation_log")
 def run(context: AgentContext) -> AgentContext:
     context.response = "Generated quote PDF"  # placeholder
     context.source_reliability = 0.95
-    logger.info("quote created")
     logger.info(
-        f"reliability={context.source_reliability} error={context.error_flag}"
+        "quote created",
+        extra={
+            "confidence_score": context.confidence,
+            "source_reliability": context.source_reliability,
+            "clarification_attempted": context.clarification_attempted,
+            "error_flag": context.error_flag,
+        },
     )
     return context

--- a/agents/response_agent.py
+++ b/agents/response_agent.py
@@ -28,8 +28,13 @@ def run(context: AgentContext) -> AgentContext:
         )
         context.source_reliability = 0.5
         mode = "simple"
-    logger.info(f"{mode}:{context.response}")
     logger.info(
-        f"reliability={context.source_reliability} error={context.error_flag}"
+        f"{mode}:{context.response}",
+        extra={
+            "confidence_score": context.confidence,
+            "source_reliability": context.source_reliability,
+            "clarification_attempted": context.clarification_attempted,
+            "error_flag": context.error_flag,
+        },
     )
     return context

--- a/agents/supervisor_agent.py
+++ b/agents/supervisor_agent.py
@@ -23,8 +23,13 @@ def run(context: AgentContext) -> AgentContext:
         if errors:
             suggestions.append(f"Review {path.name}: {errors} issues")
     context.response = "; ".join(suggestions) if suggestions else "No issues"
-    logger.info(context.response)
     logger.info(
-        f"reliability={context.source_reliability} error={context.error_flag}"
+        context.response,
+        extra={
+            "confidence_score": context.confidence,
+            "source_reliability": context.source_reliability,
+            "clarification_attempted": context.clarification_attempted,
+            "error_flag": context.error_flag,
+        },
     )
     return context

--- a/agents/translation_agent.py
+++ b/agents/translation_agent.py
@@ -23,8 +23,13 @@ def run(context: AgentContext, target_lang: str, style: str = "neutral") -> Agen
     context.response = translated
     context.language = target_lang
     context.source_reliability = 0.6
-    logger.info(f"translated to {target_lang} style={style}")
     logger.info(
-        f"reliability={context.source_reliability} error={context.error_flag}"
+        f"translated to {target_lang} style={style}",
+        extra={
+            "confidence_score": context.confidence,
+            "source_reliability": context.source_reliability,
+            "clarification_attempted": context.clarification_attempted,
+            "error_flag": context.error_flag,
+        },
     )
     return context

--- a/agents/verification_agent.py
+++ b/agents/verification_agent.py
@@ -21,8 +21,13 @@ def run(context: AgentContext) -> bool:
         result = False
         classification = "invalid"
     context.error_flag = classification == "invalid"
-    logger.info(classification)
     logger.info(
-        f"reliability={context.source_reliability} error={context.error_flag}"
+        classification,
+        extra={
+            "confidence_score": context.confidence,
+            "source_reliability": context.source_reliability,
+            "clarification_attempted": context.clarification_attempted,
+            "error_flag": context.error_flag,
+        },
     )
     return result

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,22 @@
+import os
+from utils.logger import get_logger
+
+
+def test_logger_fields(tmp_path):
+    os.chdir(tmp_path)
+    logger = get_logger("sample")
+    logger.info(
+        "hello",
+        extra={
+            "confidence_score": 0.5,
+            "source_reliability": 0.8,
+            "clarification_attempted": True,
+            "error_flag": False,
+        },
+    )
+    log_file = tmp_path / "logs" / "sample.log"
+    text = log_file.read_text()
+    assert "confidence=0.5" in text
+    assert "reliability=0.8" in text
+    assert "clarification=True" in text
+    assert "error=False" in text

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -2,6 +2,23 @@ import logging
 from pathlib import Path
 import sys
 
+EXTRA_FIELDS = (
+    "confidence_score",
+    "source_reliability",
+    "clarification_attempted",
+    "error_flag",
+)
+
+
+class _ContextFilter(logging.Filter):
+    """Ensure default values for custom log record fields."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # type: ignore[override]
+        for field in EXTRA_FIELDS:
+            if not hasattr(record, field):
+                setattr(record, field, "")
+        return True
+
 YELLOW = "\x1b[33m"
 WHITE = "\x1b[37m"
 RESET = "\x1b[0m"
@@ -18,12 +35,21 @@ def get_logger(name: str) -> logging.Logger:
     log_dir = Path("logs")
     log_dir.mkdir(exist_ok=True)
     file_handler = logging.FileHandler(log_dir / f"{name}.log")
-    file_handler.setFormatter(logging.Formatter("%(asctime)s - %(message)s"))
+    file_fmt = (
+        "%(asctime)s - %(message)s - "
+        "confidence=%(confidence_score)s "
+        "reliability=%(source_reliability)s "
+        "clarification=%(clarification_attempted)s "
+        "error=%(error_flag)s"
+    )
+    file_handler.setFormatter(logging.Formatter(file_fmt))
+    file_handler.addFilter(_ContextFilter())
     logger.addHandler(file_handler)
 
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setFormatter(
         logging.Formatter(f"{YELLOW}[%(name)s]{WHITE} %(message)s{RESET}")
     )
+    console_handler.addFilter(_ContextFilter())
     logger.addHandler(console_handler)
     return logger


### PR DESCRIPTION

- extend logger to include confidence, reliability, clarification and error info
- log these fields from all agents
- test that logger writes the extra fields
