### PR TITLE
Add LLM-driven log analysis

### DIFF
--- a/tests/test_supervisor_agent.py
+++ b/tests/test_supervisor_agent.py
@@ -10,6 +10,10 @@ def test_supervisor_agent(tmp_path, monkeypatch):
         "agents.supervisor_agent.LOG_FILES",
         [log_dir / "intent_log.log", log_dir / "validation_log.log"],
     )
+    monkeypatch.setattr(
+        "agents.supervisor_agent.call_mistral",
+        lambda prompt: "Improve intent detection; Refine response verification",
+    )
     ctx = AgentContext(user_id="u", session_id="s", input="")
     run(ctx)
     assert "intent" in ctx.response
@@ -24,6 +28,7 @@ def test_supervisor_no_issues(tmp_path, monkeypatch):
         "agents.supervisor_agent.LOG_FILES",
         [log_dir / "intent_log.log", log_dir / "validation_log.log"],
     )
+    monkeypatch.setattr("agents.supervisor_agent.call_mistral", lambda prompt: "")
     ctx = AgentContext(user_id="u", session_id="s", input="")
     run(ctx)
     assert ctx.response == "No issues"


### PR DESCRIPTION
## Summary
- enhance `SupervisorAgent` to analyse logs with Mistral and fall back to heuristics
- adapt supervisor tests for the new LLM call

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d1f63c500832d9942875c8a89d9a7