### PR TITLE
Improve clarification prompt context usage

### DIFF
--- a/agents/context.py
+++ b/agents/context.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 
 @dataclass
@@ -21,3 +21,4 @@ class AgentContext:
     reasoning_trace: str = ""
     source_reliability: float = 0.0
     error_flag: bool = False
+    conversation_history: List[Tuple[str, str]] = field(default_factory=list)

--- a/agents/orchestrator_agent.py
+++ b/agents/orchestrator_agent.py
@@ -73,6 +73,7 @@ def choose_agent_sequence(context: AgentContext):
 
 
 def run(context: AgentContext) -> AgentContext:
+    context.conversation_history.append(("user", context.input))
     original_input = context.input
     for step in choose_agent_sequence(context):
         if step is detect_intent:
@@ -95,6 +96,7 @@ def run(context: AgentContext) -> AgentContext:
         clarify(context)
 
     translate(context, context.language)
+    context.conversation_history.append(("assistant", context.response or ""))
     logger.info(
         "orchestration complete",
         extra={

--- a/clarification_prompt.py
+++ b/clarification_prompt.py
@@ -3,6 +3,7 @@
 from models.mistral import call_mistral
 from config.intents_config import ALLOWED_INTENTS
 from language_detector import detect_language
+from agents.context import AgentContext
 
 def generate_fallback_question(user_input: str) -> str:
     """
@@ -26,6 +27,39 @@ def generate_fallback_question(user_input: str) -> str:
         f"The goal is to distinguish between intents such as: {intent_list}.\n"
         "Your response must be ONLY the question, in the same language as the user.\n"
         f"\nUser message: \"{user_input}\"\n"
+        "\nClarification question:"
+    )
+
+    try:
+        return call_mistral(prompt).strip()
+    except Exception:
+        fallback_prompt = (
+            f"Translate the following sentence into {lang}: 'Could you clarify your request?'"
+        )
+        return call_mistral(fallback_prompt).strip()
+
+
+def generate_contextual_question(context: AgentContext) -> str:
+    """Generate a clarification question using extra context."""
+
+    lang = context.language or detect_language(context.input)
+    intent_list = ", ".join(sorted(ALLOWED_INTENTS))
+    reasoning = context.reasoning_trace or ""
+    prev_answer = context.response or ""
+    history_lines = []
+    for role, msg in context.conversation_history[-4:]:
+        history_lines.append(f"{role.capitalize()}: {msg}")
+    history = "\n".join(history_lines)
+
+    prompt = (
+        f"You are an AI assistant that replies in the same language as the user's message (detected language: {lang}).\n"
+        "The user's intent was unclear and a clarification is required.\n"
+        f"System reasoning so far: {reasoning}\n"
+        f"Current system answer: {prev_answer}\n"
+        + (f"Conversation so far:\n{history}\n" if history else "")
+        + f"Generate ONE short, precise follow-up question to clarify the request.\n"
+        f"Possible intents include: {intent_list}.\n"
+        f"\nUser message: \"{context.input}\"\n"
         "\nClarification question:"
     )
 

--- a/main.py
+++ b/main.py
@@ -9,12 +9,14 @@ RESET = "\x1b[0m"
 def main():
     print("💬 Kchat\n")
 
+    context = AgentContext(session_id='qwerty', user_id="power_user", input="")
+
     while True:
         user_input = input(f"{RED}User:{RESET} ")
         if user_input.strip().lower() in ["exit", "quit"]:
             break
 
-        context = AgentContext(session_id='qwerty',user_id="power_user", input=user_input)
+        context.input = user_input
         context = orchestrate(context)
         print(f"{GREEN}Bot:{RESET} {context.response}\n")
 

--- a/tests/test_clarification_agent.py
+++ b/tests/test_clarification_agent.py
@@ -5,8 +5,12 @@ from agents.clarification_agent import run
 
 def test_clarification_agent(monkeypatch):
     monkeypatch.setattr(
+        "agents.clarification_agent.generate_contextual_question",
+        lambda ctx: "what do you mean?",
+    )
+    monkeypatch.setattr(
         "agents.clarification_agent.generate_fallback_question",
-        lambda text: "what do you mean?",
+        lambda text: "should not be used",
     )
     monkeypatch.setattr("agents.clarification_agent.HISTORY_FILE", Path("/tmp/empty.log"))
     Path("/tmp/empty.log").write_text("")
@@ -18,8 +22,8 @@ def test_clarification_agent(monkeypatch):
 
 def test_clarification_formal(monkeypatch):
     monkeypatch.setattr(
-        "agents.clarification_agent.generate_fallback_question",
-        lambda text: "pu\u00f2 chiarire?",
+        "agents.clarification_agent.generate_contextual_question",
+        lambda ctx: "pu\u00f2 chiarire?",
     )
     ctx = AgentContext(user_id="u", session_id="s", input="hi", formality="formal")
     run(ctx)
@@ -31,9 +35,51 @@ def test_clarification_dynamic(monkeypatch, tmp_path):
     log.write_text("a?\na?\nb?\n")
     monkeypatch.setattr("agents.clarification_agent.HISTORY_FILE", log)
     monkeypatch.setattr(
+        "agents.clarification_agent.generate_contextual_question",
+        lambda ctx: "dynamic",
+    )
+    monkeypatch.setattr(
         "agents.clarification_agent.generate_fallback_question",
         lambda text: "unused",
     )
     ctx = AgentContext(user_id="u", session_id="s", input="hi")
     run(ctx)
-    assert ctx.response == "a?"
+    assert ctx.response == "dynamic"
+
+
+def test_clarification_fallback_to_history(monkeypatch, tmp_path):
+    log = tmp_path / "clarification_log.log"
+    log.write_text("hist?\nhist?\n")
+    monkeypatch.setattr("agents.clarification_agent.HISTORY_FILE", log)
+
+    def raise_ctx(ctx):
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(
+        "agents.clarification_agent.generate_contextual_question", raise_ctx
+    )
+    monkeypatch.setattr(
+        "agents.clarification_agent.generate_fallback_question", raise_ctx
+    )
+    ctx = AgentContext(user_id="u", session_id="s", input="hi")
+    run(ctx)
+    assert ctx.response == "hist?"
+
+
+def test_contextual_prompt_includes_history(monkeypatch):
+    captured = {}
+
+    def fake_call(prompt: str) -> str:
+        captured["prompt"] = prompt
+        return "sure?"
+
+    monkeypatch.setattr("clarification_prompt.call_mistral", fake_call)
+    ctx = AgentContext(
+        user_id="u",
+        session_id="s",
+        input="next",
+        conversation_history=[("user", "first"), ("assistant", "what?")],
+    )
+    run(ctx)
+    assert "first" in captured["prompt"]
+    assert ctx.response == "sure?"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -12,3 +12,4 @@ def test_defaults():
     assert ctx.formality is None
     assert ctx.mixed_language is False
     assert ctx.reasoning_trace == ""
+    assert ctx.conversation_history == []

--- a/tests/test_orchestrator_agent.py
+++ b/tests/test_orchestrator_agent.py
@@ -36,6 +36,7 @@ def test_orchestrator_sequence_quote(monkeypatch):
     assert ctx.reasoning_trace == "quote"
     assert called["r"] == 1
     assert ctx.response == "ok"
+    assert ctx.conversation_history == [("user", "price?"), ("assistant", "ok")]
 
 
 def test_orchestrator_sequence_smalltalk(monkeypatch):
@@ -55,6 +56,7 @@ def test_orchestrator_sequence_smalltalk(monkeypatch):
     assert ctx.reasoning_trace == "chat"
     assert called["r"] == 0
     assert ctx.response == "ok"
+    assert ctx.conversation_history == [("user", "hello"), ("assistant", "ok")]
 
 
 def test_translation_before_intent(monkeypatch):
@@ -80,3 +82,19 @@ def test_translation_before_intent(monkeypatch):
     ctx = AgentContext(user_id="u", session_id="s", input="bonjour")
     run(ctx)
     assert called["intent_input"] == "bonjour-en"
+    assert ctx.conversation_history == [("user", "bonjour"), ("assistant", "ok")]
+
+
+def test_conversation_history_grows(monkeypatch):
+    _common_patches(monkeypatch)
+    monkeypatch.setattr("agents.orchestrator_agent.verify", lambda ctx: True)
+    ctx = AgentContext(user_id="u", session_id="s", input="hi")
+    run(ctx)
+    ctx.input = "again"
+    run(ctx)
+    assert ctx.conversation_history == [
+        ("user", "hi"),
+        ("assistant", "ok"),
+        ("user", "again"),
+        ("assistant", "ok"),
+    ]


### PR DESCRIPTION

- generate clarification questions using reasoning and prior response
- fall back to simple generation, then history log when needed
- adjust tests for contextual question logic
- add conversation memory across turns
