### PR TITLE
Add NER support to categorizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ HTML o archivi ZIP) e assegnare una categoria e delle sotto-categorie in base al
 contenuto. I log generati durante la procedura vengono salvati in `logs/` nei
 file `categorizer_log.json`, `extract_log.json` e `validator_log.json`.
 
+La versione attuale include anche un modulo di **Named Entity Recognition (NER)** basato su spaCy che
+riconosce nomi di prodotti e software all'interno dei testi. Le entità estratte
+vengono combinate con i token più frequenti per calcolare le sotto-categorie e
+sono salvate nei metadati dell'output, così da poter essere indicizzate nel
+sistema di embedding.
+
 Per utilizzare il tool da linea di comando:
 
 ```bash

--- a/agents/embedding_ingestor_agent.py
+++ b/agents/embedding_ingestor_agent.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+from typing import Any, Mapping
+
 from agents.context import AgentContext
 from utils.logger import get_logger
 
@@ -9,7 +11,7 @@ from utils.logger import get_logger
 logger = get_logger("ingest_log")
 
 
-def run(context: AgentContext, path: str | Path) -> AgentContext:
+def run(context: AgentContext, path: str | Path, metadata: Mapping[str, Any] | None = None) -> AgentContext:
     path = Path(path)
     if path.exists():
         text = path.read_text()
@@ -19,6 +21,8 @@ def run(context: AgentContext, path: str | Path) -> AgentContext:
     embeddings = [hash(c) % 1000 for c in chunks]
     context.documents = [f"{path.name}-{i}" for i, _ in enumerate(embeddings)]
     context.source_reliability = 1.0
+    if metadata:
+        context.reasoning_trace = str(metadata.get("entities", []))
     logger.info(
         f"ingested {len(chunks)} chunks from {path.name}",
         extra={

--- a/categorizer/__init__.py
+++ b/categorizer/__init__.py
@@ -1,6 +1,7 @@
 from .categorizer import Categorizer
 from .classifier import classify, score, extract_subcategories
 from .extractor import extract_text
+from .entity_extractor import extract_entities
 from .scanner import scan
 from .validator import confirm
 
@@ -10,6 +11,7 @@ __all__ = [
     "score",
     "extract_subcategories",
     "extract_text",
+    "extract_entities",
     "scan",
     "confirm",
 ]

--- a/categorizer/categorizer.py
+++ b/categorizer/categorizer.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from .scanner import scan
 from .extractor import extract_text
 from .classifier import classify
+from .entity_extractor import extract_entities
 from .validator import confirm
 
 from utils.logger import get_json_logger
@@ -29,12 +30,14 @@ class Categorizer:
             mode=self.mode,
             confidence=conf,
         )
+        entities = extract_entities(text)
         metadata = {
             "filename": path.name,
             "extension": path.suffix.lower(),
             "file_size_kb": path.stat().st_size // 1024,
             "word_count": len(text.split()),
             "processed_at": datetime.utcnow().isoformat(),
+            "entities": entities,
         }
         logger.info(
             "processed",

--- a/categorizer/entity_extractor.py
+++ b/categorizer/entity_extractor.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import List
+
+import spacy
+
+
+@lru_cache(maxsize=1)
+def _get_nlp() -> spacy.language.Language:
+    """Load and cache the multilingual NER model."""
+    try:
+        return spacy.load("xx_ent_wiki_sm")
+    except OSError:
+        from spacy.cli import download
+
+        download("xx_ent_wiki_sm")
+        return spacy.load("xx_ent_wiki_sm")
+
+
+def extract_entities(text: str) -> List[str]:
+    """Return product or software names detected via NER."""
+    nlp = _get_nlp()
+    doc = nlp(text)
+    entities: List[str] = []
+    seen: set[str] = set()
+    for ent in doc.ents:
+        if ent.label_ in {"ORG", "MISC", "PRODUCT", "WORK_OF_ART"}:
+            val = ent.text.strip()
+            if val and val.lower() not in seen:
+                seen.add(val.lower())
+                entities.append(val)
+    return entities

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ beautifulsoup4
 qdrant-client
 openai
 openpyxl
+spacy

--- a/tests/test_embedding_ingestor_agent.py
+++ b/tests/test_embedding_ingestor_agent.py
@@ -4,6 +4,7 @@ from agents.embedding_ingestor_agent import run
 
 def test_embedding_ingestor_agent():
     ctx = AgentContext(user_id="u", session_id="s", input="file")
-    run(ctx, "dummy.txt")
+    run(ctx, "dummy.txt", metadata={"entities": ["KChat"]})
     assert len(ctx.documents) >= 1
+    assert "KChat" in ctx.reasoning_trace
 

--- a/tests/test_entity_extractor.py
+++ b/tests/test_entity_extractor.py
@@ -1,0 +1,8 @@
+from categorizer.entity_extractor import extract_entities
+
+
+def test_extract_entities():
+    text = "L'errore compare in Microsoft Word quando avvio KChat."
+    ents = extract_entities(text)
+    assert "Microsoft Word" in ents
+    assert "KChat" in ents

--- a/tests/test_file_classifier.py
+++ b/tests/test_file_classifier.py
@@ -53,6 +53,7 @@ def test_categorizer_run(tmp_path: Path):
     results = cat.run(tmp_path)
     assert results[0]["category"] == "tech_assistance"
     assert "speaker" in results[0]["subcategories"]
+    assert "entities" in results[0]["metadata"]
 
 
 def test_extract_xlsx(tmp_path: Path):


### PR DESCRIPTION

- create lightweight entity extractor using spaCy multilingual model
- enhance `extract_subcategories` to include entities from NER
- store entities in categorizer metadata
- expose entities in categorizer API
- propagate entities to embedding ingestor agent
- add unit tests for entity extraction and updated ingestor
- install spaCy dependency
- document NER extraction in README
