### PR TITLE
Improve README quick install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Kchat è concepito per funzionare interamente in locale senza dipendenze da serv
 
 ### Installazione rapida
 
+Per poter eseguire correttamente i test (`pytest`, `ruff .`, `mypy .`) è
+necessario installare prima tutte le dipendenze elencate in
+`requirements.txt` (ad esempio `python-json-logger`, `python-docx`,
+`openpyxl`, `qdrant-client`). L'esecuzione dei test senza questi pacchetti
+fallirà.
+
 ```bash
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
## Summary
- clarify which packages tests depend on
- show pip install example in quick install section

## Testing
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub)*
- `pytest -q` *(fails: ModuleNotFoundError for pythonjsonlogger, qdrant_client, docx)*

------
https://chatgpt.com/codex/tasks/task_e_684dfaaff66c832d927f2ffae9294e45