### PR TITLE
Add forced category option and API for file classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,16 @@ vengono combinate con i token più frequenti per calcolare le sotto-categorie e
 sono salvate nei metadati dell'output, così da poter essere indicizzate nel
 sistema di embedding.
 
-Per utilizzare il tool da linea di comando:
+Per utilizzare il tool da linea di comando è ora obbligatorio specificare la
+categoria principale del documento. Le categorie ammesse sono:
+
+- `tech_assistance`
+- `software_assistance`
+- `product_price`
+- `product_guide`
 
 ```bash
-python file_classifier.py <cartella_o_zip> --mode auto
+python file_classifier.py <cartella_o_zip> --category tech_assistance --mode auto
 ```
 
 L'opzione `--mode` può assumere i valori:
@@ -133,6 +139,21 @@ L'opzione `--mode` può assumere i valori:
 
 L'output verrà scritto in `output.json` con i campi `category`, `subcategories`,
 `validated`, `category_source` e metadati sul file processato.
+
+È disponibile anche un endpoint REST per classificare file tramite HTTP.
+Avviare il server con:
+
+```bash
+uvicorn file_classifier:app --reload
+```
+
+Una volta in esecuzione si può inviare una richiesta POST a `/classify`:
+
+```bash
+curl -X POST http://localhost:8000/classify \
+  -H "Content-Type: application/json" \
+  -d '{"input_path": "cartella/", "category": "product_guide"}'
+```
 
 ## Come eseguire il debug
 

--- a/categorizer/categorizer.py
+++ b/categorizer/categorizer.py
@@ -15,21 +15,27 @@ logger = get_json_logger("categorizer_log")
 
 
 class Categorizer:
-    def __init__(self, mode: str = "interactive", threshold: float = 0.9) -> None:
+    def __init__(self, mode: str = "interactive", threshold: float = 0.9, main_category: str | None = None) -> None:
         self.mode = mode
         self.threshold = threshold
+        self.main_category = main_category
 
     def process_file(self, path: Path) -> dict:
         text = extract_text(path)
         category, subcats, conf, ambiguous = classify(text, path.name)
-        category, subcats, validated, source, conf = confirm(
-            category,
-            subcats,
-            text,
-            path.name,
-            mode=self.mode,
-            confidence=conf,
-        )
+        if self.main_category:
+            category = self.main_category
+            validated = True
+            source = "forced"
+        else:
+            category, subcats, validated, source, conf = confirm(
+                category,
+                subcats,
+                text,
+                path.name,
+                mode=self.mode,
+                confidence=conf,
+            )
         entities = extract_entities(text)
         metadata = {
             "filename": path.name,

--- a/docs/WIKI.md
+++ b/docs/WIKI.md
@@ -131,8 +131,21 @@ python main.py
 Per classificare documenti in automatico:
 
 ```bash
-python file_classifier.py <cartella_o_zip> --mode auto
+python file_classifier.py <cartella_o_zip> \
+  --category tech_assistance --mode auto
 ```
+
+Le categorie valide sono `tech_assistance`, `software_assistance`,
+`product_price` e `product_guide`.
+
+È inoltre possibile avviare un piccolo server REST:
+
+```bash
+uvicorn file_classifier:app --reload
+```
+
+ed effettuare una richiesta POST a `/classify` specificando `input_path` e
+`category` nel corpo JSON.
 
 La cartella `tests/` contiene suite PyTest che coprono le funzioni principali. Prima di mettere in produzione il progetto è consigliato eseguire:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ qdrant-client
 openai
 openpyxl
 spacy
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add mandatory `--category` arg to file_classifier
- expose simple REST API endpoint `/classify`
- allow `Categorizer` to enforce a given category
- extend tests for forced category and REST API
- update dependencies
- document mandatory `--category` and REST API usage

## Testing
- `ruff check .`
- `mypy .` *(fails: missing type stubs for spacy, pythonjsonlogger, openai, pdfminer, qdrant_client)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7a01b608832d8d64253919d929bd