### PR TITLE
Add chunk builders for file categorizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,12 @@ L'opzione `--mode` può assumere i valori:
 * `silent` – nessuna validazione interattiva.
 
 L'output verrà scritto in `output.json` con i campi `category`, `subcategories`,
-`validated`, `category_source` e metadati sul file processato.
+`validated`, `category_source`, `chunks` e metadati sul file processato.
+
+Il campo `chunks` rappresenta le porzioni di testo da usare nel retrieval (RAG) e varia in base alla categoria:
+- `product_price`: ogni riga di tabella viene convertita in un dizionario `{serial, subcategory, description, price}`;
+- `product_guide`: il documento è diviso in paragrafi;
+- altre categorie: suddivisione standard per paragrafi.
 
 È disponibile anche un endpoint REST per classificare file tramite HTTP.
 Avviare il server con:

--- a/categorizer/__init__.py
+++ b/categorizer/__init__.py
@@ -4,6 +4,7 @@ from .extractor import extract_text
 from .entity_extractor import extract_entities
 from .scanner import scan
 from .validator import confirm
+from .chunk_builders import build_chunks, build_price_chunks, build_guide_chunks
 
 __all__ = [
     "Categorizer",
@@ -14,4 +15,7 @@ __all__ = [
     "extract_entities",
     "scan",
     "confirm",
+    "build_chunks",
+    "build_price_chunks",
+    "build_guide_chunks",
 ]

--- a/categorizer/categorizer.py
+++ b/categorizer/categorizer.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from .scanner import scan
 from .extractor import extract_text
 from .classifier import classify
+from .chunk_builders import build_chunks
 from .entity_extractor import extract_entities
 from .validator import confirm
 
@@ -45,6 +46,7 @@ class Categorizer:
             "processed_at": datetime.utcnow().isoformat(),
             "entities": entities,
         }
+        chunks = build_chunks(text, category) if category else []
         logger.info(
             "processed",
             extra={
@@ -62,6 +64,7 @@ class Categorizer:
             "metadata": metadata,
             "category_source": source,
             "confidence": conf,
+            "chunks": chunks,
         }
 
     def run(self, root: Path) -> list[dict]:

--- a/categorizer/chunk_builders.py
+++ b/categorizer/chunk_builders.py
@@ -1,0 +1,39 @@
+"""Utility functions to build retrieval chunks based on document category."""
+
+from __future__ import annotations
+
+from typing import List, Dict, Any
+
+
+def build_price_chunks(text: str) -> List[Dict[str, str]]:
+    """Parse a price table text into structured rows."""
+    rows: List[Dict[str, str]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.lower().startswith("serial"):
+            continue
+        parts = [p.strip() for p in line.split("|")]
+        if len(parts) >= 4 and parts[0].isdigit():
+            rows.append(
+                {
+                    "serial": parts[0],
+                    "subcategory": parts[1],
+                    "description": parts[2],
+                    "price": parts[3],
+                }
+            )
+    return rows
+
+
+def build_guide_chunks(text: str) -> List[str]:
+    """Split guide-like documents into paragraphs."""
+    return [p.strip() for p in text.split("\n\n") if p.strip()]
+
+
+def build_chunks(text: str, category: str) -> List[Any]:
+    """Dispatch to the correct chunk builder for the given category."""
+    if category == "product_price":
+        return build_price_chunks(text)
+    if category == "product_guide":
+        return build_guide_chunks(text)
+    return [p.strip() for p in text.split("\n\n") if p.strip()]

--- a/tests/test_chunk_builders.py
+++ b/tests/test_chunk_builders.py
@@ -1,0 +1,20 @@
+from categorizer.chunk_builders import build_price_chunks, build_chunks
+
+PRICE_TABLE = """
+Serial | Subcategory | Description | Price
+1 | Hardware | Base kit | 50
+2 | Software | Pro kit | 100
+"""
+
+def test_build_price_chunks():
+    rows = build_price_chunks(PRICE_TABLE)
+    assert rows == [
+        {"serial": "1", "subcategory": "Hardware", "description": "Base kit", "price": "50"},
+        {"serial": "2", "subcategory": "Software", "description": "Pro kit", "price": "100"},
+    ]
+
+
+def test_build_chunks_dispatch():
+    chunks = build_chunks(PRICE_TABLE, "product_price")
+    assert len(chunks) == 2
+    assert chunks[0]["serial"] == "1"


### PR DESCRIPTION

- split price tables and guides with new chunk builders
- expose `build_chunks` in categorizer and return `chunks` from processing
- test price chunk generation
- document chunks field in README
