### PR TITLE
Support newline price table format

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ L'output verrà scritto in `output.json` con i campi `category`, `subcategories`
 `validated`, `category_source`, `chunks` e metadati sul file processato.
 
 Il campo `chunks` rappresenta le porzioni di testo da usare nel retrieval (RAG) e varia in base alla categoria:
-- `product_price`: ogni riga di tabella viene convertita in un dizionario `{serial, subcategory, description, price}`;
+- `product_price`: la tabella può essere in formato `a | b | c` oppure con i valori su linee consecutive (come da estrazione XLSX). Ogni riga viene convertita in un dizionario `{serial, subcategory, description, price}`;
 - `product_guide`: il documento è diviso in paragrafi;
 - altre categorie: suddivisione standard per paragrafi.
 

--- a/categorizer/chunk_builders.py
+++ b/categorizer/chunk_builders.py
@@ -8,20 +8,50 @@ from typing import List, Dict, Any
 def build_price_chunks(text: str) -> List[Dict[str, str]]:
     """Parse a price table text into structured rows."""
     rows: List[Dict[str, str]] = []
+    sequential: List[str] = []
+
     for line in text.splitlines():
         line = line.strip()
-        if not line or line.lower().startswith("serial"):
+        if not line:
             continue
-        parts = [p.strip() for p in line.split("|")]
-        if len(parts) >= 4 and parts[0].isdigit():
-            rows.append(
-                {
-                    "serial": parts[0],
-                    "subcategory": parts[1],
-                    "description": parts[2],
-                    "price": parts[3],
-                }
-            )
+
+        if "|" in line:
+            if line.lower().startswith("serial"):
+                continue
+            parts = [p.strip() for p in line.split("|")]
+            if len(parts) >= 4 and parts[0].isdigit():
+                rows.append(
+                    {
+                        "serial": parts[0],
+                        "subcategory": parts[1],
+                        "description": parts[2],
+                        "price": parts[3],
+                    }
+                )
+        else:
+            sequential.append(line)
+
+    if sequential:
+        headers = ["serial", "subcategory", "description", "price"]
+        lowered = [s.lower() for s in sequential]
+        if lowered[:4] == headers:
+            sequential = sequential[4:]
+
+        for i in range(0, len(sequential), 4):
+            chunk = sequential[i : i + 4]
+            if len(chunk) < 4:
+                break
+            serial, subcategory, description, price = [c.strip() for c in chunk]
+            if serial.isdigit():
+                rows.append(
+                    {
+                        "serial": serial,
+                        "subcategory": subcategory,
+                        "description": description,
+                        "price": price,
+                    }
+                )
+
     return rows
 
 

--- a/tests/test_chunk_builders.py
+++ b/tests/test_chunk_builders.py
@@ -6,8 +6,31 @@ Serial | Subcategory | Description | Price
 2 | Software | Pro kit | 100
 """
 
+PRICE_LINES = """
+Serial
+Subcategory
+Description
+Price
+1
+Hardware
+Base kit
+50
+2
+Software
+Pro kit
+100
+"""
+
 def test_build_price_chunks():
     rows = build_price_chunks(PRICE_TABLE)
+    assert rows == [
+        {"serial": "1", "subcategory": "Hardware", "description": "Base kit", "price": "50"},
+        {"serial": "2", "subcategory": "Software", "description": "Pro kit", "price": "100"},
+    ]
+
+
+def test_build_price_chunks_newline_format():
+    rows = build_price_chunks(PRICE_LINES)
     assert rows == [
         {"serial": "1", "subcategory": "Hardware", "description": "Base kit", "price": "50"},
         {"serial": "2", "subcategory": "Software", "description": "Pro kit", "price": "100"},
@@ -18,3 +41,9 @@ def test_build_chunks_dispatch():
     chunks = build_chunks(PRICE_TABLE, "product_price")
     assert len(chunks) == 2
     assert chunks[0]["serial"] == "1"
+
+
+def test_build_chunks_dispatch_newline():
+    chunks = build_chunks(PRICE_LINES, "product_price")
+    assert len(chunks) == 2
+    assert chunks[1]["price"] == "100"


### PR DESCRIPTION

- parse product price tables where cells are split on newlines
- test newline based price table parsing
- document newline parsing logic in README
