### PR TITLE
Refactor price table parsing and tests

### DIFF
--- a/models/mistral.py
+++ b/models/mistral.py
@@ -1,8 +1,8 @@
 import subprocess
 from typing import Iterator
 
-def call_mistral(prompt: str) -> str:
-    cmd = ["ollama", "run", "mistral"]
+def call_mistral(prompt: str, model: str = "mistral") -> str:
+    cmd = ["ollama", "run", model]
     proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     out, _ = proc.communicate(prompt)
     return out.strip()

--- a/tests/test_chunk_builders.py
+++ b/tests/test_chunk_builders.py
@@ -1,4 +1,6 @@
+import pandas as pd
 from categorizer.chunk_builders import parse_price_table, build_chunks
+from categorizer.price_chunk_builder import parse_price_table_from_excel
 
 PRICE_TABLE = """
 Serial | Subcategory | Description | Price
@@ -47,3 +49,34 @@ def test_build_chunks_dispatch_newline():
     chunks = build_chunks(PRICE_LINES, "product_price")
     assert len(chunks) == 2
     assert chunks[1]["price"] == "100"
+
+
+def test_parse_price_table_from_csv(monkeypatch, tmp_path):
+    csv = tmp_path / "prices.csv"
+    csv.write_text("code,name,cost\n1,Base kit,50\n2,Pro kit,100\n")
+    df = pd.read_csv(csv)
+    monkeypatch.setattr(
+        "categorizer.price_chunk_builder.infer_column_mapping_with_llm",
+        lambda _df: {"serial": "code", "description": "name", "price": "cost"},
+    )
+    rows = parse_price_table_from_excel(df)
+    assert rows == [
+        {"serial": "1", "subcategory": "", "description": "Base kit", "price": "50"},
+        {"serial": "2", "subcategory": "", "description": "Pro kit", "price": "100"},
+    ]
+
+
+def test_parse_price_table_from_excel(monkeypatch, tmp_path):
+    data = pd.DataFrame({"id": ["1", "2"], "desc": ["A", "B"], "price": ["10", "20"]})
+    xls = tmp_path / "data.xlsx"
+    data.to_excel(xls, index=False)
+    df = pd.read_excel(xls)
+    monkeypatch.setattr(
+        "categorizer.price_chunk_builder.infer_column_mapping_with_llm",
+        lambda _df: {"serial": "id", "description": "desc", "price": "price"},
+    )
+    rows = parse_price_table_from_excel(df)
+    assert rows == [
+        {"serial": "1", "subcategory": "", "description": "A", "price": "10"},
+        {"serial": "2", "subcategory": "", "description": "B", "price": "20"},
+    ]

--- a/utils/csv_utils.py
+++ b/utils/csv_utils.py
@@ -17,10 +17,12 @@ def load_csv(path: str | Path) -> list[dict[str, Any]]:
     p = Path(path)
     try:
         df = pd.read_csv(p)
+        if all(str(c).isdigit() for c in df.columns):
+            raise ValueError("numeric_header")
     except Exception:
         df = pd.read_csv(p, header=None)
-        df.columns = [f"col_{i}" for i in range(len(df.columns))]
-    return df.fillna("").to_dict(orient="records")
+        df.columns = [f"col_{i}" for i in range(len(df.columns))]  # type: ignore[assignment]
+    return df.fillna("").to_dict(orient="records")  # type: ignore[return-value]
 
 
 def summarize_csv(path: str | Path, sample_rows: int = 3) -> str:


### PR DESCRIPTION
## Summary
- extend `call_mistral` with optional model argument
- reuse `parse_price_table` logic for Excel parsing
- improve CSV heuristics and header detection in price table parser
- add unit tests for CSV and Excel parsing

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68514125a894832d9c0873e502ab07df