### PR TITLE
Ensure parent category precedes subcategory

### DIFF
--- a/categorizer/price_chunk_builder.py
+++ b/categorizer/price_chunk_builder.py
@@ -170,14 +170,15 @@ def parse_price_table(
             if not re.match(r"^\d+(\.\d+)?$", price):
                 continue
 
-            sub_value = parts[sub_idx].strip() if sub_idx is not None else current_sub
-            subs = []
+            sub_value = parts[sub_idx].strip() if sub_idx is not None else None
             if sub_value:
-                subs.append(sub_value)
-            elif current_sub:
-                subs.append(current_sub)
+                current_sub = sub_value
+
+            subs = []
             if parent_category:
                 subs.append(parent_category)
+            if current_sub:
+                subs.append(current_sub)
             output.append({
                 "serial": serial,
                 "subcategory": ", ".join(subs) if subs else "",

--- a/tests/test_chunk_builders.py
+++ b/tests/test_chunk_builders.py
@@ -39,6 +39,14 @@ def test_parse_price_table_newline_format():
     ]
 
 
+def test_parse_price_table_with_parent():
+    rows = parse_price_table(PRICE_TABLE, parent_category="Main")
+    assert rows == [
+        {"serial": "1", "subcategory": "Main, Hardware", "description": "Base kit", "price": "50"},
+        {"serial": "2", "subcategory": "Main, Software", "description": "Pro kit", "price": "100"},
+    ]
+
+
 def test_build_chunks_dispatch():
     chunks = build_chunks(PRICE_TABLE, "product_price")
     assert len(chunks) == 2


### PR DESCRIPTION

- handle subcategory order correctly in `parse_price_table`
- test that both parent and subcategory values appear
