### PR TITLE
Improve UI theme and modularity

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState, useMemo } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { ThemeProvider, CssBaseline } from '@mui/material';
-import muiTheme from './theme/muiTheme';
+import getMuiTheme from './theme/muiTheme';
+import ColorModeContext from './theme/ColorModeContext';
 import Layout from './components/Layout';
 import ChatInterface from './components/ChatInterface';
 import StreamingChatInterface from './components/StreamingChatInterface';
@@ -15,9 +16,24 @@ import './styles/ModernUI.css';
 import './styles/MUIAnimations.css';
 
 function App() {
+  const [mode, setMode] = useState(() => localStorage.getItem('colorMode') || 'light');
+  const colorMode = useMemo(
+    () => ({
+      toggleColorMode: () => {
+        setMode(prev => {
+          const next = prev === 'light' ? 'dark' : 'light';
+          localStorage.setItem('colorMode', next);
+          return next;
+        });
+      }
+    }),
+    []
+  );
+  const theme = useMemo(() => getMuiTheme(mode), [mode]);
   return (
-    <ThemeProvider theme={muiTheme}>
-      <CssBaseline />
+    <ColorModeContext.Provider value={colorMode}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
       <Router>
         <Routes>
           {/* New MUI Interface as Default */}
@@ -58,7 +74,8 @@ function App() {
           } />
         </Routes>
       </Router>
-    </ThemeProvider>
+      </ThemeProvider>
+    </ColorModeContext.Provider>
   );
 }
 

--- a/frontend/src/components/MUIModernChatInterface.jsx
+++ b/frontend/src/components/MUIModernChatInterface.jsx
@@ -1,8 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import {
   Box,
-  Card,
-  CardContent,
   TextField,
   Button,
   Typography,
@@ -10,174 +8,23 @@ import {
   Chip,
   Paper,
   Collapse,
-  IconButton,
   Container,
   Stack,
   Divider,
-  Fade,
   Slide,
   LinearProgress,
 } from '@mui/material';
 import MUIResponsiveLayout from './MUIResponsiveLayout';
 import {
   Send as SendIcon,
-  Android as BotIcon,
-  Person as PersonIcon,
   ExpandMore as ExpandMoreIcon,
   ExpandLess as ExpandLessIcon,
-  ContentCopy as CopyIcon,
-  ThumbUp as ThumbUpIcon,
-  Stars as SparklesIcon,
-  Description as FileTextIcon,
-  Launch as ExternalLinkIcon,
   Psychology as PsychologyIcon,
   Schedule as ClockIcon,
 } from '@mui/icons-material';
+import MessageCard from './MessageCard';
 
-function MUIMessageCard({ message, onCopy, onFeedback }) {
-  const [isHovered, setIsHovered] = useState(false);
-  const [showActions, setShowActions] = useState(false);
-  const isUser = message.type === 'user';
-  const hasError = message.isError;
-
-  const getMessageCardSx = () => ({
-    mb: 3,
-    borderRadius: 5,
-    overflow: 'hidden',
-    background: isUser
-      ? 'linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)'
-      : hasError
-        ? 'linear-gradient(135deg, #fee2e2 0%, #fecaca 100%)'
-        : 'white',
-    border: isUser
-      ? '1px solid rgba(59, 130, 246, 0.2)'
-      : hasError
-        ? '1px solid rgba(239, 68, 68, 0.2)'
-        : '1px solid rgba(226, 232, 240, 0.6)',
-    boxShadow: isUser
-      ? '0 4px 20px rgba(59, 130, 246, 0.15)'
-      : hasError
-        ? '0 4px 20px rgba(239, 68, 68, 0.15)'
-        : 3,
-    transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-    transform: isHovered ? 'translateY(-2px)' : 'translateY(0)',
-    position: 'relative',
-  });
-
-  return (
-    <Slide direction="up" in={true} timeout={400}>
-      <Card
-        sx={getMessageCardSx()}
-        onMouseEnter={() => {
-          setIsHovered(true);
-          setShowActions(true);
-        }}
-        onMouseLeave={() => {
-          setIsHovered(false);
-          setShowActions(false);
-        }}
-      >
-        <CardContent sx={{ p: 3, '&:last-child': { pb: 3 } }}>
-          <Box display="flex" gap={2} alignItems="flex-start">
-            <Avatar
-              sx={{
-                width: 44,
-                height: 44,
-                background: isUser
-                  ? 'rgba(255, 255, 255, 0.2)'
-                  : 'linear-gradient(135deg, #0a0a0a 0%, #1e1e1e 100%)',
-                boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
-                backdropFilter: 'blur(10px)',
-              }}
-            >
-              {isUser ? <PersonIcon /> : <BotIcon />}
-            </Avatar>
-            <Box flex={1} position="relative">
-              {message.isStreaming && (
-                <Box display="flex" alignItems="center" gap={1} mb={1}>
-                  <SparklesIcon sx={{ fontSize: 16, animation: 'pulse 1.5s infinite' }} />
-                  <Typography variant="caption" fontWeight={500}>
-                    K-Array AI sta pensando...
-                  </Typography>
-                </Box>
-              )}
-              <Typography
-                variant="body1"
-                sx={{
-                  color: isUser ? 'white' : hasError ? 'error.main' : 'text.primary',
-                  lineHeight: 1.6,
-                  fontWeight: isUser ? 500 : 400,
-                  whiteSpace: 'pre-wrap',
-                  wordBreak: 'break-word',
-                }}
-              >
-                {message.content}
-                {message.isStreaming && (
-                  <Box component="span" sx={{ ml: 0.5, animation: 'pulse 1s infinite' }}>●</Box>
-                )}
-              </Typography>
-              {message.sources && message.sources.length > 0 && (
-                <Paper
-                  elevation={0}
-                  sx={{
-                    mt: 2,
-                    p: 2,
-                    background: 'rgba(255, 255, 255, 0.9)',
-                    backdropFilter: 'blur(10px)',
-                    borderRadius: 3,
-                    border: '1px solid rgba(0, 0, 0, 0.05)',
-                  }}
-                >
-                  <Box display="flex" alignItems="center" gap={1} mb={1.5}>
-                    <FileTextIcon sx={{ fontSize: 16 }} />
-                    <Typography variant="subtitle2" fontWeight={600}>
-                      Fonti documentali
-                    </Typography>
-                  </Box>
-                  <Stack spacing={1}>
-                    {message.sources.map((source, index) => (
-                      <Chip
-                        key={index}
-                        icon={<ExternalLinkIcon sx={{ fontSize: 14 }} />}
-                        label={typeof source === 'string' ? source : source.snippet}
-                        size="small"
-                        sx={{
-                          backgroundColor: 'rgba(59, 130, 246, 0.05)',
-                          color: 'primary.main',
-                          '& .MuiChip-icon': { color: 'primary.main' },
-                          justifyContent: 'flex-start',
-                        }}
-                      />
-                    ))}
-                  </Stack>
-                </Paper>
-              )}
-              <Fade in={showActions && !isUser}>
-                <Box position="absolute" top={-10} right={0} display="flex" gap={1}>
-                  <IconButton
-                    size="small"
-                    onClick={() => onCopy && onCopy(message.content)}
-                    sx={{ bgcolor: 'rgba(255, 255, 255, 0.9)', boxShadow: 2 }}
-                  >
-                    <CopyIcon sx={{ fontSize: 16 }} />
-                  </IconButton>
-                  <IconButton
-                    size="small"
-                    onClick={() => onFeedback && onFeedback(message, 'positive')}
-                    sx={{ bgcolor: 'rgba(255, 255, 255, 0.9)', color: 'success.main', boxShadow: 2 }}
-                  >
-                    <ThumbUpIcon sx={{ fontSize: 16 }} />
-                  </IconButton>
-                </Box>
-              </Fade>
-            </Box>
-          </Box>
-        </CardContent>
-      </Card>
-    </Slide>
-  );
-}
-
+ 
 function MUIReasoningPanel({ steps, isExpanded, onToggle }) {
   return (
     <Paper
@@ -308,7 +155,7 @@ export default function MUIModernChatInterface() {
           <Paper elevation={3} sx={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', borderRadius: 4 }}>
             <Box flex={1} sx={{ overflowY: 'auto', p: 3 }}>
               {messages.map((message) => (
-                <MUIMessageCard key={message.id} message={message} onCopy={handleCopy} onFeedback={handleFeedback} />
+                <MessageCard key={message.id} message={message} onCopy={handleCopy} onFeedback={handleFeedback} />
               ))}
               {isLoading && (
                 <Box sx={{ mb: 3 }}>

--- a/frontend/src/components/MUIResponsiveLayout.jsx
+++ b/frontend/src/components/MUIResponsiveLayout.jsx
@@ -32,10 +32,14 @@ import {
   Home as HomeIcon,
   Help as HelpIcon,
   Brightness4 as DarkModeIcon,
+  Brightness7 as LightModeIcon,
   Notifications as NotificationsIcon,
 } from '@mui/icons-material';
+import { useContext } from 'react';
+import ColorModeContext from '../theme/ColorModeContext';
 
 function MUIResponsiveLayout({ children }) {
+  const colorMode = useContext(ColorModeContext);
   const [mobileOpen, setMobileOpen] = useState(false);
   const [bottomNavValue, setBottomNavValue] = useState(0);
   const theme = useTheme();
@@ -255,8 +259,8 @@ function MUIResponsiveLayout({ children }) {
             <IconButton color="inherit" size="large">
               <NotificationsIcon />
             </IconButton>
-            <IconButton color="inherit" size="large">
-              <DarkModeIcon />
+            <IconButton color="inherit" size="large" onClick={colorMode.toggleColorMode}>
+              {theme.palette.mode === 'light' ? <DarkModeIcon /> : <LightModeIcon />}
             </IconButton>
             <IconButton color="inherit" size="large">
               <SettingsIcon />

--- a/frontend/src/components/MessageCard.jsx
+++ b/frontend/src/components/MessageCard.jsx
@@ -1,0 +1,167 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Avatar,
+  Chip,
+  Paper,
+  IconButton,
+  Fade,
+  Stack,
+  Slide
+} from '@mui/material';
+import {
+  Android as BotIcon,
+  Person as PersonIcon,
+  ContentCopy as CopyIcon,
+  ThumbUp as ThumbUpIcon,
+  Stars as SparklesIcon,
+  Description as FileTextIcon,
+  Launch as ExternalLinkIcon
+} from '@mui/icons-material';
+
+export default function MessageCard({ message, onCopy, onFeedback }) {
+  const [isHovered, setIsHovered] = useState(false);
+  const [showActions, setShowActions] = useState(false);
+  const isUser = message.type === 'user';
+  const hasError = message.isError;
+
+  const getMessageCardSx = () => ({
+    mb: 3,
+    borderRadius: 5,
+    overflow: 'hidden',
+    background: isUser
+      ? 'linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)'
+      : hasError
+        ? 'linear-gradient(135deg, #fee2e2 0%, #fecaca 100%)'
+        : 'white',
+    border: isUser
+      ? '1px solid rgba(59, 130, 246, 0.2)'
+      : hasError
+        ? '1px solid rgba(239, 68, 68, 0.2)'
+        : '1px solid rgba(226, 232, 240, 0.6)',
+    boxShadow: isUser
+      ? '0 4px 20px rgba(59, 130, 246, 0.15)'
+      : hasError
+        ? '0 4px 20px rgba(239, 68, 68, 0.15)'
+        : 3,
+    transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+    transform: isHovered ? 'translateY(-2px)' : 'translateY(0)',
+    position: 'relative'
+  });
+
+  return (
+    <Slide direction="up" in={true} timeout={400}>
+      <Card
+        sx={getMessageCardSx()}
+        onMouseEnter={() => {
+          setIsHovered(true);
+          setShowActions(true);
+        }}
+        onMouseLeave={() => {
+          setIsHovered(false);
+          setShowActions(false);
+        }}
+      >
+        <CardContent sx={{ p: 3, '&:last-child': { pb: 3 } }}>
+          <Box display="flex" gap={2} alignItems="flex-start">
+            <Avatar
+              sx={{
+                width: 44,
+                height: 44,
+                background: isUser
+                  ? 'rgba(255, 255, 255, 0.2)'
+                  : 'linear-gradient(135deg, #0a0a0a 0%, #1e1e1e 100%)',
+                boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+                backdropFilter: 'blur(10px)'
+              }}
+            >
+              {isUser ? <PersonIcon /> : <BotIcon />}
+            </Avatar>
+            <Box flex={1} position="relative">
+              {message.isStreaming && (
+                <Box display="flex" alignItems="center" gap={1} mb={1}>
+                  <SparklesIcon sx={{ fontSize: 16, animation: 'pulse 1.5s infinite' }} />
+                  <Typography variant="caption" fontWeight={500}>
+                    K-Array AI sta pensando...
+                  </Typography>
+                </Box>
+              )}
+              <Typography
+                variant="body1"
+                sx={{
+                  color: isUser ? 'white' : hasError ? 'error.main' : 'text.primary',
+                  lineHeight: 1.6,
+                  fontWeight: isUser ? 500 : 400,
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word'
+                }}
+              >
+                {message.content}
+                {message.isStreaming && (
+                  <Box component="span" sx={{ ml: 0.5, animation: 'pulse 1s infinite' }}>●</Box>
+                )}
+              </Typography>
+              {message.sources && message.sources.length > 0 && (
+                <Paper
+                  elevation={0}
+                  sx={{
+                    mt: 2,
+                    p: 2,
+                    background: 'rgba(255, 255, 255, 0.9)',
+                    backdropFilter: 'blur(10px)',
+                    borderRadius: 3,
+                    border: '1px solid rgba(0, 0, 0, 0.05)'
+                  }}
+                >
+                  <Box display="flex" alignItems="center" gap={1} mb={1.5}>
+                    <FileTextIcon sx={{ fontSize: 16 }} />
+                    <Typography variant="subtitle2" fontWeight={600}>
+                      Fonti documentali
+                    </Typography>
+                  </Box>
+                  <Stack spacing={1}>
+                    {message.sources.map((source, index) => (
+                      <Chip
+                        key={index}
+                        icon={<ExternalLinkIcon sx={{ fontSize: 14 }} />}
+                        label={typeof source === 'string' ? source : source.snippet}
+                        size="small"
+                        sx={{
+                          backgroundColor: 'rgba(59, 130, 246, 0.05)',
+                          color: 'primary.main',
+                          '& .MuiChip-icon': { color: 'primary.main' },
+                          justifyContent: 'flex-start'
+                        }}
+                      />
+                    ))}
+                  </Stack>
+                </Paper>
+              )}
+              <Fade in={showActions && !isUser}>
+                <Box position="absolute" top={-10} right={0} display="flex" gap={1}>
+                  <IconButton
+                    size="small"
+                    onClick={() => onCopy && onCopy(message.content)}
+                    sx={{ bgcolor: 'rgba(255, 255, 255, 0.9)', boxShadow: 2 }}
+                  >
+                    <CopyIcon sx={{ fontSize: 16 }} />
+                  </IconButton>
+                  <IconButton
+                    size="small"
+                    onClick={() => onFeedback && onFeedback(message, 'positive')}
+                    sx={{ bgcolor: 'rgba(255, 255, 255, 0.9)', color: 'success.main', boxShadow: 2 }}
+                  >
+                    <ThumbUpIcon sx={{ fontSize: 16 }} />
+                  </IconButton>
+                </Box>
+              </Fade>
+            </Box>
+          </Box>
+        </CardContent>
+      </Card>
+    </Slide>
+  );
+}

--- a/frontend/src/theme/ColorModeContext.js
+++ b/frontend/src/theme/ColorModeContext.js
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+const ColorModeContext = createContext({
+  toggleColorMode: () => {}
+});
+
+export default ColorModeContext;

--- a/frontend/src/theme/muiTheme.js
+++ b/frontend/src/theme/muiTheme.js
@@ -44,24 +44,39 @@ const karrayColors = {
 };
 
 // Create MUI Theme
-const muiTheme = createTheme({
+const getMuiTheme = (mode = 'light') => createTheme({
   palette: {
-    mode: 'light',
+    mode,
     primary: karrayColors.primary,
     secondary: karrayColors.secondary,
     success: karrayColors.success,
     warning: karrayColors.warning,
     error: karrayColors.error,
-    background: {
-      default: '#f8fafc',
-      paper: '#ffffff',
-    },
-    text: {
-      primary: '#0f172a',
-      secondary: '#64748b',
-      disabled: '#94a3b8',
-    },
-    divider: '#e2e8f0',
+    ...(mode === 'light'
+      ? {
+          background: {
+            default: '#f8fafc',
+            paper: '#ffffff',
+          },
+          text: {
+            primary: '#0f172a',
+            secondary: '#64748b',
+            disabled: '#94a3b8',
+          },
+          divider: '#e2e8f0',
+        }
+      : {
+          background: {
+            default: '#121212',
+            paper: '#1e1e1e',
+          },
+          text: {
+            primary: '#ffffff',
+            secondary: '#cbd5e1',
+            disabled: '#94a3b8',
+          },
+          divider: 'rgba(255, 255, 255, 0.12)',
+        }),
     grey: {
       50: '#f8fafc',
       100: '#f1f5f9',
@@ -246,4 +261,4 @@ const muiTheme = createTheme({
   },
 });
 
-export default muiTheme;
+export default getMuiTheme;


### PR DESCRIPTION
## Summary
- modularize chat message card component
- add color mode context and dynamic light/dark theme
- integrate theme toggle button in responsive layout
- update UI components to use new MessageCard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68652163bb98832dbda8a93083954724